### PR TITLE
Fix repetitive call to Network on rotation

### DIFF
--- a/app/src/main/java/com/parassidhu/coronavirusapp/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/parassidhu/coronavirusapp/ui/main/MainActivity.kt
@@ -66,7 +66,6 @@ class MainActivity : BaseActivity(), AppBarLayout.OnOffsetChangedListener, Count
 
     private fun init() {
         showLoading(true)
-        makeApiCalls()
         setupObservers()
         setupRecyclerView()
         setListeners()

--- a/app/src/main/java/com/parassidhu/coronavirusapp/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/parassidhu/coronavirusapp/ui/main/MainViewModel.kt
@@ -14,6 +14,13 @@ class MainViewModel @Inject constructor(
     private val repo: MainRepo
 ): ViewModel() {
 
+    init {
+        viewModelScope.launch {
+            getCountryWiseCases()
+            getWorldStats()
+        }
+    }
+
     fun getCountryWiseCases() {
         viewModelScope.launch {
             val response = repo.getCountryWiseCases()


### PR DESCRIPTION
Remove makeApiCalls from activity as it gets called on each rotation which leads to hitting the API multiple times. Instead, call them once on viewModel init and again only when user refreshes.